### PR TITLE
done_button_in_form

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -12,7 +12,7 @@ class MemosController < ApplicationController
     @memo.date = Time.now.to_s.slice(0..9)
     @memo.save
     respond_to do |format|
-      format.html {redirect_to today_schedules_path}
+      format.html {redirect_to today_tasks_path}
       format.json
     end 
   end
@@ -21,7 +21,7 @@ class MemosController < ApplicationController
     @memo = Memo.find(params[:id])
     @memo.destroy
     respond_to do |format|
-      format.html {redirect_to today_schedules_path}
+      format.html {redirect_to today_tasks_path}
       format.json
     end
   end

--- a/app/views/layouts/_form_bar.html.haml
+++ b/app/views/layouts/_form_bar.html.haml
@@ -51,6 +51,12 @@
       .new-schedule.lineheight10
         %p ▼スケジュール内容
         = f.text_area :description, class: 'form-control__large', placeholder: "作業内容等を入力"
+      .new-done
+        %p ▼スケジュール進捗
+        = f.radio_button :done, :false, checked: true
+        = f.label :done, "未完了"
+        = f.radio_button :done, :true
+        = f.label :done, "完了済"
       - if controller.controller_name == "tasks" && controller.action_name == "new"
         .new-submit
           = f.submit '登録', class: 'btn-post'


### PR DESCRIPTION
# what
・スケジュール登録、編集のフォーム内でスケジュールの完了と未完了も選択できるようにした。
・memoコントローラーの軽微な修正

# why
以前の仕様だと一度完了したスケジュールを元に戻すことができなかった為